### PR TITLE
fix: patch Log4Shell (Critical) and High CVEs in prerender image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,12 @@ RUN npm i express-jwt
 RUN npm i basic-auth
 RUN npm i express
 
+# Pin vulnerable transitive deps to safe versions (Sysdig CVE remediation)
+RUN npm i qs@6.14.2 ws@7.5.10 body-parser@1.20.3 path-to-regexp@0.1.13 jws@3.2.3 uuid@11.1.1 redis@3.1.1
+
 #Trigger rules for sysdig agent scan
-ADD https://archive.apache.org/dist/logging/log4j/2.14.1/apache-log4j-2.14.1-bin.tar.gz /root
-RUN tar xzvf /root/apache-log4j-2.14.1-bin.tar.gz
+ADD https://archive.apache.org/dist/logging/log4j/2.25.4/apache-log4j-2.25.4-bin.tar.gz /root
+RUN tar xzvf /root/apache-log4j-2.25.4-bin.tar.gz
 
 # Copy server.js to container
 COPY ./docker-prerender/server.js /app/server.js


### PR DESCRIPTION
## Summary

This PR remediates **2 Critical** and **9 High** CVEs detected by Sysdig in the `koton00beng/prerender:main` image running in the `default` namespace.

- Updates Log4j from `2.14.1` to `2.25.4` (fixes Log4Shell and subsequent log4j CVEs)
- Pins vulnerable transitive npm dependencies to safe versions

## Vulnerability Details

### Critical

| CVE | Package | From | To |
|-----|---------|------|----|
| CVE-2021-44228 | log4j-core | 2.14.1 | 2.25.4 |
| CVE-2021-45046 | log4j-core | 2.14.1 | 2.25.4 |

### High

| CVE | Package | Safe Version |
|-----|---------|-------------|
| CVE-2026-34480 | log4j-core | 2.25.4 |
| CVE-2026-34479 | log4j-1.2-api | 2.25.4 |
| CVE-2026-2391 | qs | 6.14.2 |
| CVE-2025-15284 | qs | 6.14.2 |
| CVE-2024-37890 | ws | 7.5.10 |
| CVE-2024-45590 | body-parser | 1.20.3 |
| CVE-2026-4867 | path-to-regexp | 0.1.13 |
| CVE-2025-65945 | jws | 3.2.3 |
| CVE-2026-41907 | uuid | 11.1.1 |
| CVE-2021-29469 | redis | 3.1.1 |

## Version Resolution (Log4j)

The direct fix for CVE-2021-44228 (`2.15.0`) was skipped because intermediate versions each introduce new Critical/High CVEs.

Resolution chain: `2.14.1 → 2.25.4`

`2.25.4` verified clean (zero Critical/High CVEs) via Sysdig threat intelligence.

## Notes

- `redis` pinned to `3.1.1` (v3 line) to preserve `server.js` API compatibility — v4+ has breaking API changes
- Transitive npm deps pinned via explicit `npm i <pkg>@<version>` after the main installs so they override whatever versions the parent packages would otherwise resolve

## References

- Detected by: Sysdig Secure — workload `prerender`, namespace `default`
- Investigated with: Claude Code + Sysdig MCP